### PR TITLE
Feat: Make interfaces available for consumers of the library

### DIFF
--- a/AllDebridNET/AllDebridNETClient.cs
+++ b/AllDebridNET/AllDebridNETClient.cs
@@ -1,20 +1,31 @@
 ﻿namespace AllDebridNET;
 
+public interface IAllDebridNETClient
+{
+    IAuthenticationApi Authentication { get; }
+    IHostsApi Hosts { get; }
+    ILinksApi Links { get; }
+    IMagnetApi Magnet { get; }
+    ISystemApi System { get; set; }
+    IUserApi User { get; }
+    IUserLinksApi UserLink { get; set; }
+}
+
 /// <summary>
 ///     The AllDebridNET consumed the alldebrid.com API.
 ///     Documentation about the API can be found here: https://docs.alldebrid.com/
 /// </summary>
-public class AllDebridNETClient
+public class AllDebridNETClient : IAllDebridNETClient
 {
     private readonly Store _store = new();
 
-    public AuthenticationApi Authentication { get; }
-    public HostsApi Hosts { get; }
-    public LinksApi Links { get; }
-    public MagnetApi Magnet { get; }
-    public SystemApi System { get; set; }
-    public UserApi User { get; }
-    public UserLinksApi UserLink { get; set; }
+    public IAuthenticationApi Authentication { get; }
+    public IHostsApi Hosts { get; }
+    public ILinksApi Links { get; }
+    public IMagnetApi Magnet { get; }
+    public ISystemApi System { get; set; }
+    public IUserApi User { get; }
+    public IUserLinksApi UserLink { get; set; }
 
     /// <summary>
     ///     Initialize the AllDebridNET API.
@@ -44,12 +55,12 @@ public class AllDebridNETClient
         _store.Agent = agent;
         _store.ApiKey = apiKey;
 
-        Authentication = new(client, _store);
-        Hosts = new(client, _store);
-        Links = new(client, _store);
-        Magnet = new(client, _store);
-        System = new(client, _store);
-        User = new(client, _store);
-        UserLink = new(client, _store);
+        Authentication = new AuthenticationApi(client, _store);
+        Hosts = new HostsApi(client, _store);
+        Links = new LinksApi(client, _store);
+        Magnet = new MagnetApi(client, _store);
+        System = new SystemApi(client, _store);
+        User = new UserApi(client, _store);
+        UserLink = new UserLinksApi(client, _store);
     }
 }

--- a/AllDebridNET/Apis/Authentication.cs
+++ b/AllDebridNET/Apis/Authentication.cs
@@ -1,16 +1,7 @@
 ﻿namespace AllDebridNET;
 
-public class AuthenticationApi
+public interface IAuthenticationApi
 {
-    private readonly Store _store;
-    private readonly Requests _requests;
-
-    internal AuthenticationApi(HttpClient httpClient, Store store)
-    {
-        _store = store;
-        _requests = new(httpClient, store);
-    }
-
     /// <summary>
     ///     Get the pin authentication object.
     /// </summary>
@@ -21,15 +12,8 @@ public class AuthenticationApi
     /// <returns>
     ///     Redirect the user to the resulting "BaseUrl" or "UserUrl" then use CheckPin to verify if the user completed entering the pin.
     /// </returns>
-    public async Task<PinRequest> GetPinAsync(CancellationToken cancellationToken = default)
-    {
-        var parameters = new Dictionary<String, String>();
-#if DEBUG
-        parameters.Add("demo", "");
-#endif
-        return await _requests.GetRequestAsync<PinRequest>("pin/get", false, parameters, cancellationToken);
-    }
-
+    Task<PinRequest> GetPinAsync(CancellationToken cancellationToken = default);
+    
     /// <summary>
     ///     The endpoint where the auth apikey will be available after the user submitted the PIN code on the Alldebrid website.
     ///     The endpoint is available for 10 minutes after the PIN code is generated.
@@ -46,6 +30,31 @@ public class AuthenticationApi
     ///     A cancellation token that can be used by other objects or threads to receive notice of
     ///     cancellation.
     /// </param>
+    Task<PinCheck> CheckPinAsync(String pinCheck, String pin, CancellationToken cancellationToken = default);
+}
+
+public class AuthenticationApi : IAuthenticationApi
+{
+    private readonly Store _store;
+    private readonly Requests _requests;
+
+    internal AuthenticationApi(HttpClient httpClient, Store store)
+    {
+        _store = store;
+        _requests = new(httpClient, store);
+    }
+    
+    /// <inheritdoc/>>
+    public async Task<PinRequest> GetPinAsync(CancellationToken cancellationToken = default)
+    {
+        var parameters = new Dictionary<String, String>();
+#if DEBUG
+        parameters.Add("demo", "");
+#endif
+        return await _requests.GetRequestAsync<PinRequest>("pin/get", false, parameters, cancellationToken);
+    }
+
+    /// <inheritdoc />
     public async Task<PinCheck> CheckPinAsync(String pinCheck, String pin, CancellationToken cancellationToken = default)
     {
         var parameters = new Dictionary<String, String>

--- a/AllDebridNET/Apis/Hosts.cs
+++ b/AllDebridNET/Apis/Hosts.cs
@@ -1,14 +1,7 @@
 ﻿namespace AllDebridNET;
 
-public class HostsApi
+public interface IHostsApi
 {
-    private readonly Requests _requests;
-
-    internal HostsApi(HttpClient httpClient, Store store)
-    {
-        _requests = new(httpClient, store);
-    }
-        
     /// <summary>
     ///     Use this endpoint to retrieve informations about what hosts we support and all related informations about it.
     ///     This request does not require authentication.
@@ -17,10 +10,7 @@ public class HostsApi
     ///     A cancellation token that can be used by other objects or threads to receive notice of
     ///     cancellation.
     /// </param>
-    public async Task<Hosts> GetHostsAsync(CancellationToken cancellationToken = default)
-    {
-        return await _requests.GetRequestAsync<Hosts>("hosts", false, null, cancellationToken);
-    }
+    Task<Hosts> GetHostsAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Use this endpoint to only retrieve the list of supported hosts domains and redirectors as an array. This will also include
@@ -31,11 +21,8 @@ public class HostsApi
     ///     A cancellation token that can be used by other objects or threads to receive notice of
     ///     cancellation.
     /// </param>
-    public async Task<HostDomains> GetDomainsAsync(CancellationToken cancellationToken = default)
-    {
-        return await _requests.GetRequestAsync<HostDomains>($"hosts/domains", false, null, cancellationToken);
-    }
-        
+    Task<HostDomains> GetDomainsAsync(CancellationToken cancellationToken = default);
+
     /// <summary>
     ///     Not all hosts are created equal, so some hosts are more limited than other.
     ///     Use this endpoint to retrieve an ordered list of main domain of hosts, from more open to more restricted.
@@ -45,12 +32,7 @@ public class HostsApi
     ///     A cancellation token that can be used by other objects or threads to receive notice of
     ///     cancellation.
     /// </param>
-    public async Task<Dictionary<String, Int64>> GetHostsPriorityAsync(CancellationToken cancellationToken = default)
-    {
-        var response = await _requests.GetRequestAsync<HostsPriorityResponse>($"hosts/priority", false, null, cancellationToken);
-
-        return response.Hosts ?? [];
-    }
+    Task<Dictionary<String, Int64>> GetHostsPriorityAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     This endpoint retrieves a complete list of all available hosts for this user. Depending of the account subscription status
@@ -62,6 +44,39 @@ public class HostsApi
     ///     A cancellation token that can be used by other objects or threads to receive notice of
     ///     cancellation.
     /// </param>
+    Task<Hosts> GetHostsForUserAsync(CancellationToken cancellationToken = default);
+}
+
+public class HostsApi : IHostsApi
+{
+    private readonly Requests _requests;
+
+    internal HostsApi(HttpClient httpClient, Store store)
+    {
+        _requests = new(httpClient, store);
+    }
+        
+   /// <inheritdoc />
+    public async Task<Hosts> GetHostsAsync(CancellationToken cancellationToken = default)
+    {
+        return await _requests.GetRequestAsync<Hosts>("hosts", false, null, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<HostDomains> GetDomainsAsync(CancellationToken cancellationToken = default)
+    {
+        return await _requests.GetRequestAsync<HostDomains>($"hosts/domains", false, null, cancellationToken);
+    }
+        
+    /// <inheritdoc />
+    public async Task<Dictionary<String, Int64>> GetHostsPriorityAsync(CancellationToken cancellationToken = default)
+    {
+        var response = await _requests.GetRequestAsync<HostsPriorityResponse>($"hosts/priority", false, null, cancellationToken);
+
+        return response.Hosts ?? [];
+    }
+
+    /// <inheritdoc />
     public async Task<Hosts> GetHostsForUserAsync(CancellationToken cancellationToken = default)
     {
         return await _requests.GetRequestAsync<Hosts>($"user/hosts", true, null, cancellationToken);

--- a/AllDebridNET/Apis/Magnet.cs
+++ b/AllDebridNET/Apis/Magnet.cs
@@ -1,14 +1,7 @@
 ﻿namespace AllDebridNET;
 
-public class MagnetApi
+public interface IMagnetApi
 {
-    private readonly Requests _requests;
-
-    internal MagnetApi(HttpClient httpClient, Store store)
-    {
-        _requests = new(httpClient, store);
-    }
-
     /// <summary>
     ///     Upload a magnet with its URI or hash.
     /// </summary>
@@ -19,6 +12,92 @@ public class MagnetApi
     ///     A cancellation token that can be used by other objects or threads to receive notice of
     ///     cancellation.
     /// </param>
+    Task<MagnetAddResult?> UploadMagnetAsync(String magnetLink, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///     Upload torrent files.
+    /// </summary>
+    /// <param name="file">
+    ///     The file as a byte array.
+    /// </param>
+    /// <param name="cancellationToken">
+    ///     A cancellation token that can be used by other objects or threads to receive notice of
+    ///     cancellation.
+    /// </param>
+    Task<MagnetAddResult?> UploadFileAsync(Byte[] file, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///     Get the status of current magnets.
+    /// </summary>
+    /// <param name="status">Magnets status filter. Either active, ready, expired or error</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>
+    ///     List of Magnet
+    /// </returns>
+    Task<List<Magnet>> StatusAllAsync(String? status = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///     Get the status of current magnets.
+    /// </summary>
+    /// <param name="magnetId">
+    ///     Magnet ID.
+    /// </param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>
+    ///     The Magnet or null.
+    /// </returns>
+    Task<Magnet?> StatusAsync(String magnetId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///    The Live Mode allows to only get the new data of the status of current magnets. It is designed to make a "live" panel or monitoring system more performant when consuming the magnet/status endpoint very frequently.
+    ///    It requires a session ID and a counter, and using cache on the API side only the differences between the last state and the current state are sent, greatly reducing the amount of data returned by the API on each call.
+    ///    The client using this mode must keep the current state of the magnets status locally between each call in order to apply the new data on the last state to get the whole current state.
+    ///    A fixed session ID (integer) must be randomly set, and a counter starting at 0 will be used. On the first call (id=123, counter=0) with a new session ID, all the current data will be sent back, with the fullsync property set to true to make it clear, and the next counter to use. On the next call the updated counter is used (id=123, counter=1), and only the differences with the previous state will be send back.
+    ///    If the magnets property returned is empty, then no change happened since the last call. If some changes happened, the magnets array will have some magnet objects (see Status) with its id and the properties changed, like this :
+    ///    { "id": 123456, "downloaded": 258879224, "downloadSpeed": 20587738 }
+    ///    You can them apply those diff to the last state you kept to get the current magnets status state.
+    ///    If you send a counter that is not in sync with the last call response (like sending the same counter twice in a row), then the endpoint will consider your counter invalid and will return a full fullsync reponse with a reseted counter.
+    ///    If you want to see a live implementation of this mode, it is currently in use on the magnet dashboard on Alldebrid.
+    /// </summary>
+    /// <param name="session">
+    ///     Session ID.
+    /// </param>
+    /// <param name="counter">
+    ///     Counter.
+    /// </param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task<MagnetStatusLiveResponse> StatusLiveAsync(Int64 session, Int64 counter, CancellationToken cancellationToken = default);
+
+    Task<List<File>> FilesAsync(Int64 magnetId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///     Delete a magnet.
+    /// </summary>
+    /// <param name="magnetId">Magnet ID.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task<String?> DeleteAsync(String magnetId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///     Restart a failed magnet.
+    /// </summary>
+    /// <param name="magnetId">Magnet ID.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task<String?> RestartAsync(String magnetId, CancellationToken cancellationToken = default);
+}
+
+public class MagnetApi : IMagnetApi
+{
+    private readonly Requests _requests;
+
+    internal MagnetApi(HttpClient httpClient, Store store)
+    {
+        _requests = new(httpClient, store);
+    }
+
+    /// <inheritdoc />
     public async Task<MagnetAddResult?> UploadMagnetAsync(String magnetLink, CancellationToken cancellationToken = default)
     {
         var data = new[]
@@ -63,16 +142,7 @@ public class MagnetApi
         return magnetResult;
     }
 
-    /// <summary>
-    ///     Upload torrent files.
-    /// </summary>
-    /// <param name="file">
-    ///     The file as a byte array.
-    /// </param>
-    /// <param name="cancellationToken">
-    ///     A cancellation token that can be used by other objects or threads to receive notice of
-    ///     cancellation.
-    /// </param>
+    /// <inheritdoc />
     public async Task<MagnetAddResult?> UploadFileAsync(Byte[] file, CancellationToken cancellationToken = default)
     {
         var result = await _requests.PostFileRequestAsync<MagnetUploadResponse>("magnet/upload/file", file, true, cancellationToken);
@@ -112,14 +182,7 @@ public class MagnetApi
         return fileResult;
     }
 
-    /// <summary>
-    ///     Get the status of current magnets.
-    /// </summary>
-    /// <param name="status">Magnets status filter. Either active, ready, expired or error</param>
-    /// <param name="cancellationToken"></param>
-    /// <returns>
-    ///     List of Magnet
-    /// </returns>
+    /// <inheritdoc />
     public async Task<List<Magnet>> StatusAllAsync(String? status = null, CancellationToken cancellationToken = default)
     {
         var parameters = new Dictionary<String, String>();
@@ -134,16 +197,7 @@ public class MagnetApi
         return result.Magnets ?? [];
     }
 
-    /// <summary>
-    ///     Get the status of current magnets.
-    /// </summary>
-    /// <param name="magnetId">
-    ///     Magnet ID.
-    /// </param>
-    /// <param name="cancellationToken"></param>
-    /// <returns>
-    ///     The Magnet or null.
-    /// </returns>
+    /// <inheritdoc />
     public async Task<Magnet?> StatusAsync(String magnetId, CancellationToken cancellationToken = default)
     {
         var parameters = new Dictionary<String, String>
@@ -158,25 +212,7 @@ public class MagnetApi
         return result.Magnets?.FirstOrDefault();
     }
 
-    /// <summary>
-    ///    The Live Mode allows to only get the new data of the status of current magnets. It is designed to make a "live" panel or monitoring system more performant when consuming the magnet/status endpoint very frequently.
-    ///    It requires a session ID and a counter, and using cache on the API side only the differences between the last state and the current state are sent, greatly reducing the amount of data returned by the API on each call.
-    ///    The client using this mode must keep the current state of the magnets status locally between each call in order to apply the new data on the last state to get the whole current state.
-    ///    A fixed session ID (integer) must be randomly set, and a counter starting at 0 will be used. On the first call (id=123, counter=0) with a new session ID, all the current data will be sent back, with the fullsync property set to true to make it clear, and the next counter to use. On the next call the updated counter is used (id=123, counter=1), and only the differences with the previous state will be send back.
-    ///    If the magnets property returned is empty, then no change happened since the last call. If some changes happened, the magnets array will have some magnet objects (see Status) with its id and the properties changed, like this :
-    ///    { "id": 123456, "downloaded": 258879224, "downloadSpeed": 20587738 }
-    ///    You can them apply those diff to the last state you kept to get the current magnets status state.
-    ///    If you send a counter that is not in sync with the last call response (like sending the same counter twice in a row), then the endpoint will consider your counter invalid and will return a full fullsync reponse with a reseted counter.
-    ///    If you want to see a live implementation of this mode, it is currently in use on the magnet dashboard on Alldebrid.
-    /// </summary>
-    /// <param name="session">
-    ///     Session ID.
-    /// </param>
-    /// <param name="counter">
-    ///     Counter.
-    /// </param>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public async Task<MagnetStatusLiveResponse> StatusLiveAsync(Int64 session, Int64 counter, CancellationToken cancellationToken = default)
     {
         var data = new[]
@@ -201,12 +237,7 @@ public class MagnetApi
         return magnet.Magnets?.FirstOrDefault()?.Files ?? [];
     }
 
-    /// <summary>
-    ///     Delete a magnet.
-    /// </summary>
-    /// <param name="magnetId">Magnet ID.</param>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public async Task<String?> DeleteAsync(String magnetId, CancellationToken cancellationToken = default)
     {
         var parameters = new Dictionary<String, String>
@@ -221,12 +252,7 @@ public class MagnetApi
         return result.Message;
     }
 
-    /// <summary>
-    ///     Restart a failed magnet.
-    /// </summary>
-    /// <param name="magnetId">Magnet ID.</param>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public async Task<String?> RestartAsync(String magnetId, CancellationToken cancellationToken = default)
     {
         var parameters = new Dictionary<String, String>

--- a/AllDebridNET/Apis/System.cs
+++ b/AllDebridNET/Apis/System.cs
@@ -1,6 +1,15 @@
 ﻿namespace AllDebridNET;
 
-public class SystemApi
+public interface ISystemApi
+{
+    /// <summary>
+    ///     Ping the service.
+    /// </summary>
+    /// <param name="cancellationToken"></param>
+    Task<PingResponse> PingAsync(CancellationToken cancellationToken = default);
+}
+
+public class SystemApi : ISystemApi
 {
     private readonly Requests _requests;
 
@@ -9,10 +18,7 @@ public class SystemApi
         _requests = new(httpClient, store);
     }
 
-    /// <summary>
-    ///     Ping the service.
-    /// </summary>
-    /// <param name="cancellationToken"></param>
+    /// <inheritdoc />
     public async Task<PingResponse> PingAsync(CancellationToken cancellationToken = default)
     {
         return await _requests.GetRequestAsync<PingResponse>("ping", false, null, cancellationToken);

--- a/AllDebridNET/Apis/User.cs
+++ b/AllDebridNET/Apis/User.cs
@@ -1,14 +1,7 @@
 ﻿namespace AllDebridNET;
 
-public class UserApi
+public interface IUserApi
 {
-    private readonly Requests _requests;
-
-    internal UserApi(HttpClient httpClient, Store store)
-    {
-        _requests = new(httpClient, store);
-    }
-
     /// <summary>
     ///     Use this endpoint to get user informations.
     /// </summary>
@@ -16,12 +9,7 @@ public class UserApi
     ///     A cancellation token that can be used by other objects or threads to receive notice of
     ///     cancellation.
     /// </param>
-    public async Task<User?> GetAsync(CancellationToken cancellationToken = default)
-    {
-        var user = await _requests.GetRequestAsync<UserResponse>("user", true, null, cancellationToken);
-
-        return user.User;
-    }
+    Task<User?> GetAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     This endpoint clears a user notification with its code. Current notifications codes can be retreive from the /user endpoint.
@@ -30,6 +18,43 @@ public class UserApi
     ///     Notification code to clear.
     /// </param>
     /// <param name="cancellationToken"></param>
+    Task<ActionResponse> ClearNotificationsAsync(String code, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///    When connecting from a new place, you may be asked to verify this new connection for security measures. This include the API use.
+    ///    If you trigguer such security, an email is sent to the user to confirm the new location. In those case, the api returns an AUTH_BLOCKED error, along with an token parameter as documented in the code example.
+    ///    You can use this endpoint to track the status of the new connexion validation, and retreive the apikey when the request has been confirmed by email.
+    /// </summary>
+    /// <param name="token">Verification token returned along with the AUTH_BLOCKED error</param>
+    /// <param name="cancellationToken"></param>
+    Task<VerifyEmailStatusResponse> VerifyEmailStatusAsync(String token, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///    Allow to send again the verification email, allowed once. We can referrer to the resendable property of the /user/verif response to know if you can request a resend.
+    /// </summary>
+    /// <param name="token">Verification token returned along with the AUTH_BLOCKED error</param>
+    /// <param name="cancellationToken"></param>
+    Task<ResendEmailResponse> ResendEmailNotificationAsync(String token, CancellationToken cancellationToken = default);
+}
+
+public class UserApi : IUserApi
+{
+    private readonly Requests _requests;
+
+    internal UserApi(HttpClient httpClient, Store store)
+    {
+        _requests = new(httpClient, store);
+    }
+
+    /// <inheritdoc />
+    public async Task<User?> GetAsync(CancellationToken cancellationToken = default)
+    {
+        var user = await _requests.GetRequestAsync<UserResponse>("user", true, null, cancellationToken);
+
+        return user.User;
+    }
+
+    /// <inheritdoc />
     public async Task<ActionResponse> ClearNotificationsAsync(String code, CancellationToken cancellationToken = default)
     {
         var parameters = new Dictionary<String, String>
@@ -42,13 +67,7 @@ public class UserApi
         return await _requests.GetRequestAsync<ActionResponse>("user/notification/clear", true, parameters, cancellationToken);
     }
 
-    /// <summary>
-    ///    When connecting from a new place, you may be asked to verify this new connection for security measures. This include the API use.
-    ///    If you trigguer such security, an email is sent to the user to confirm the new location. In those case, the api returns an AUTH_BLOCKED error, along with an token parameter as documented in the code example.
-    ///    You can use this endpoint to track the status of the new connexion validation, and retreive the apikey when the request has been confirmed by email.
-    /// </summary>
-    /// <param name="token">Verification token returned along with the AUTH_BLOCKED error</param>
-    /// <param name="cancellationToken"></param>
+    /// <inheritdoc />
     public async Task<VerifyEmailStatusResponse> VerifyEmailStatusAsync(String token, CancellationToken cancellationToken = default)
     {
         var data = new[]
@@ -59,11 +78,7 @@ public class UserApi
         return await _requests.PostRequestAsync<VerifyEmailStatusResponse>("user/verif", data, true, cancellationToken);
     }
 
-    /// <summary>
-    ///    Allow to send again the verification email, allowed once. We can referrer to the resendable property of the /user/verif response to know if you can request a resend.
-    /// </summary>
-    /// <param name="token">Verification token returned along with the AUTH_BLOCKED error</param>
-    /// <param name="cancellationToken"></param>
+    /// <inheritdoc />
     public async Task<ResendEmailResponse> ResendEmailNotificationAsync(String token, CancellationToken cancellationToken = default)
     {
         var data = new[]

--- a/AllDebridNET/Apis/UserLinks.cs
+++ b/AllDebridNET/Apis/UserLinks.cs
@@ -1,25 +1,13 @@
 ﻿namespace AllDebridNET;
 
-public class UserLinksApi
+public interface IUserLinksApi
 {
-    private readonly Requests _requests;
-
-    internal UserLinksApi(HttpClient httpClient, Store store)
-    {
-        _requests = new(httpClient, store);
-    }
-
     /// <summary>
     ///     Use this endpoint to get links the user saved for later use.
     /// </summary>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    public async Task<List<UserLink>> UserLinksAsync(CancellationToken cancellationToken = default)
-    {
-        var result = await _requests.GetRequestAsync<UserLinks>("user/links", true, null, cancellationToken);
-
-        return result.Links;
-    }
+    Task<List<UserLink>> UserLinksAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     ///    Use this endpoint to save links for later use.
@@ -27,12 +15,7 @@ public class UserLinksApi
     /// <param name="links">Links to save.</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    public async Task<ActionResponse> SaveLinkAsync(List<String> links, CancellationToken cancellationToken = default)
-    {
-        var data = links.Select(link => new KeyValuePair<String, String>("links[]", link)).ToList();
-
-        return await _requests.PostRequestAsync<ActionResponse>("user/links/save", data, true, cancellationToken);
-    }
+    Task<ActionResponse> SaveLinkAsync(List<String> links, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///    Use this endpoint to delete links the user saved for later use.
@@ -40,12 +23,7 @@ public class UserLinksApi
     /// <param name="links">Links to delete.</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    public async Task<ActionResponse> DeleteLinksAsync(List<String> links, CancellationToken cancellationToken = default)
-    {
-        var data = links.Select(link => new KeyValuePair<String, String>("links[]", link)).ToList();
-
-        return await _requests.PostRequestAsync<ActionResponse>($"user/links/delete", data, true, cancellationToken);
-    }
+    Task<ActionResponse> DeleteLinksAsync(List<String> links, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Use this endpoint to get recent links. Recent link logging being disabled by default, this will return nothing until history logging has been activated in your account settings.
@@ -54,12 +32,7 @@ public class UserLinksApi
     /// </summary>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    public async Task<List<UserLink>> GetHistoryAsync(CancellationToken cancellationToken = default)
-    {
-        var result = await _requests.GetRequestAsync<UserLinks>("user/history", true, null, cancellationToken);
-
-        return result.Links;
-    }
+    Task<List<UserLink>> GetHistoryAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Use this endpoint to delete all links currently in your recent links history. Links older than 3 days are automatically deleted from the recent history.
@@ -67,6 +40,51 @@ public class UserLinksApi
     /// </summary>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
+    Task<ActionResponse> DeleteHistoryAsync(CancellationToken cancellationToken = default);
+}
+
+public class UserLinksApi : IUserLinksApi
+{
+    private readonly Requests _requests;
+
+    internal UserLinksApi(HttpClient httpClient, Store store)
+    {
+        _requests = new(httpClient, store);
+    }
+
+    /// <inheritdoc />
+    public async Task<List<UserLink>> UserLinksAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await _requests.GetRequestAsync<UserLinks>("user/links", true, null, cancellationToken);
+
+        return result.Links;
+    }
+
+    /// <inheritdoc />
+    public async Task<ActionResponse> SaveLinkAsync(List<String> links, CancellationToken cancellationToken = default)
+    {
+        var data = links.Select(link => new KeyValuePair<String, String>("links[]", link)).ToList();
+
+        return await _requests.PostRequestAsync<ActionResponse>("user/links/save", data, true, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ActionResponse> DeleteLinksAsync(List<String> links, CancellationToken cancellationToken = default)
+    {
+        var data = links.Select(link => new KeyValuePair<String, String>("links[]", link)).ToList();
+
+        return await _requests.PostRequestAsync<ActionResponse>($"user/links/delete", data, true, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<List<UserLink>> GetHistoryAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await _requests.GetRequestAsync<UserLinks>("user/history", true, null, cancellationToken);
+
+        return result.Links;
+    }
+
+    /// <inheritdoc />
     public async Task<ActionResponse> DeleteHistoryAsync(CancellationToken cancellationToken = default)
     {
         return await _requests.PostRequestAsync<ActionResponse>($"user/history/delete", null, true, cancellationToken);


### PR DESCRIPTION
Adds public interfaces for everything on `AllDebridNETClient`

This makes it a lot easier to mock the AD api for projects which use `AllDebrid.NET` as their `AD` API client.

If this is merged, I'll make similar PRs for the other repos - I started here because it was first alphabetically.
So if there are any things worth keeping in mind for the other PRs, feel free to mention them here.